### PR TITLE
fix(runner): tf runner `import` command params handling

### DIFF
--- a/src/core/runner/tf/mod.rs
+++ b/src/core/runner/tf/mod.rs
@@ -136,6 +136,7 @@ impl Runner for TfRunner {
 
     fn runner(&mut self) -> Result<(), Box<dyn std::error::Error>> {
         let mut tf_args: Vec<String> = Vec::new();
+        let mut run_command = self.load.command.clone();
 
         if let Some(command) = self.load.command.first() {
             match command.as_str() {
@@ -149,6 +150,12 @@ impl Runner for TfRunner {
                     }
                     // extend vars with required env vars from unit manifest
                     tf_args.extend(self.tf_vars_args());
+
+                    if command == "import" {
+                        let import_params: Vec<String> = run_command.iter().skip(1).map(|s| s.to_string()).collect();
+                        tf_args.extend(import_params);
+                        run_command = ["import".to_string()].to_vec();
+                    }
                 }
                 _ => {}
             }
@@ -216,7 +223,7 @@ impl Runner for TfRunner {
 
         let mut child = tf_command
             .current_dir(self.load.unit.temp_folder.to_str().unwrap())
-            .args(&self.load.command)
+            .args(run_command)
             .args(tf_args)
             .envs(self.get_env_tf_vars())
             //.env("TF_DATA_DIR", &self.config.temp_folder_path)


### PR DESCRIPTION
# Pull Request Template

## Description

Fixes #41 issue with proper `import` TF command params handling

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [x] I ran bellow commands using the latest version of **rust nightly**.
- [x] I ran `cargo clippy --all -- -D warning` just before my last commit and fixed any issue that was found.
- [x] I ran `cargo fmt` just before my last commit.
- [x] I ran `cargo test` just before my last commit and all tests passed.
- [x] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or try to optimize your code or make the test easier to run. We have this rule because we have hundreds of tests to run; If each one of them took 300ms, we would have to wait for a long time.