### PR TITLE
Add comprehensive tests for configuration, dimensions, logging, and u…

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,382 @@
+# Cubtera - AI Agent Context Guide
+
+## Project Overview
+
+**Cubtera** is a Multi-dimensional Infrastructure Manager - a CLI and API tool for managing Infrastructure as Code (IaC) across multiple dimensions (environments, regions, data centers, etc.). It enables running Terraform, OpenTofu, or Bash scripts with context-aware configuration.
+
+### Key Value Proposition
+
+- Run the same IaC code across different "dimensions" without duplication
+- Hierarchical dimension relationships (e.g., `dome` → `env` → `dc`)
+- Automatic state path generation based on dimensions
+- Deployment logging with full audit trail
+- REST API for programmatic access to inventory data
+
+## Architecture
+
+```
+cubtera/
+├── src/
+│   ├── lib.rs              # Library entry point, exports prelude
+│   ├── core/               # Core business logic
+│   │   ├── cfg/            # Configuration (GLOBAL_CFG)
+│   │   ├── dim/            # Dimension management
+│   │   │   └── data/       # DataSource trait (FS/MongoDB)
+│   │   ├── dlog/           # Deployment logging
+│   │   ├── im/             # Inventory Management API
+│   │   ├── runner/         # Execution engines (TF, Bash, Tofu)
+│   │   └── unit/           # Unit & Manifest handling
+│   ├── utils/              # Helper functions
+│   └── bin/
+│       ├── cli/            # CLI binary (cubtera)
+│       └── api/            # API binary (cubtera-api)
+├── tests/                  # Integration tests
+│   ├── cli_tests.rs        # CLI command tests
+│   └── api_tests.rs        # API endpoint tests
+└── example/                # Test fixtures & example configs
+```
+
+## Core Concepts
+
+### 1. Dimensions (`core/dim/`)
+
+A **Dimension** is a logical grouping for infrastructure organization.
+
+```
+dome:prod          # Top-level dimension (e.g., production dome)
+  └── env:prod     # Environment within dome
+      └── dc:us-east-1  # Data center within env
+```
+
+**Key Files:**
+- `dim/mod.rs` - `Dim` struct and `DimBuilder` for loading dimension data
+- `dim/data/mod.rs` - `DataSource` trait, `Storage` enum (FS/DB)
+- `dim/data/jsonfile.rs` - Filesystem JSON data source
+- `dim/data/mongodb.rs` - MongoDB data source
+
+**Dimension Data Structure:**
+```json
+{
+  "name": "prod",
+  "parent": "dome:prod",
+  "meta": { "affinity_tags": ["production"] },
+  "vpc_cidr": "10.0.0.0/16"
+}
+```
+
+### 2. Units (`core/unit/`)
+
+A **Unit** is an atomic infrastructure operation defined by a manifest.
+
+**Manifest Structure (`manifest.toml`):**
+```toml
+dimensions = ["dome", "env", "dc"]  # Required dimensions
+type = "tf"                          # Runner type: tf, bash, tofu
+overwrite = true                     # Merge with generic unit
+allowList = ["prod", "staging"]      # Allowed dimension values
+denyList = ["dev"]                   # Denied dimension values
+optDims = ["region"]                 # Optional dimensions
+
+[runner]
+state_backend = "s3"
+version = "1.5.0"
+
+[state]
+bucket = "{{ org }}-tfstate"
+key = "{{ dim_tree }}/{{ unit_name }}.tfstate"
+```
+
+**Key Files:**
+- `unit/mod.rs` - `Unit` struct, file copying, dimension handling
+- `unit/manifest.rs` - `Manifest` parsing from TOML
+
+### 3. Runners (`core/runner/`)
+
+Runners execute infrastructure code.
+
+**Types:**
+- `TF` - Terraform runner (with tfswitch version management)
+- `TOFU` - OpenTofu runner (wraps TF runner)
+- `BASH` - Bash script runner
+
+**Lifecycle:**
+```
+copy_files → change_files → inlet → runner → outlet → logger
+```
+
+**Key Files:**
+- `runner/mod.rs` - `Runner` trait, `RunnerBuilder`, `RunnerType`
+- `runner/params.rs` - `RunnerParams` for version, state backend, etc.
+- `runner/tf/mod.rs` - Terraform-specific implementation
+- `runner/tf/tfswitch.rs` - Terraform version management
+- `runner/bash/mod.rs` - Bash runner
+- `runner/tofu/mod.rs` - OpenTofu runner
+
+### 4. Configuration (`core/cfg/`)
+
+Configuration is loaded from:
+1. Default values (hardcoded)
+2. Config file (`~/.cubtera/config.toml`)
+3. Environment variables (`CUBTERA_*`)
+
+**Important Environment Variables:**
+```bash
+CUBTERA_ORG          # Organization name (required)
+CUBTERA_CONFIG       # Config file path
+CUBTERA_WORKSPACE_PATH
+CUBTERA_DB           # MongoDB connection string
+CUBTERA_DLOG_DB      # Deployment log DB connection
+CUBTERA_LOG          # Log level (error, warn, info, debug)
+```
+
+**Global Config Access:**
+```rust
+use crate::globals::GLOBAL_CFG;
+
+let org = &GLOBAL_CFG.org;
+let db_client = GLOBAL_CFG.db_client.clone();
+```
+
+### 5. Inventory Management (`core/im/`)
+
+API functions for querying dimensions:
+
+```rust
+get_dim_by_name(dim_type, dim_name, org, storage, context)
+get_dim_names_by_type(dim_type, org, storage)
+get_dims_data_by_type(dim_type, org, storage)
+get_dim_defaults_by_type(dim_type, org, storage)
+get_dim_kids(dim_type, dim_name, org, storage)
+get_dim_parent(dim_type, dim_name, org, storage)
+get_all_orgs(storage)
+get_dlog(org, filter, limit)
+```
+
+### 6. Deployment Logging (`core/dlog/`)
+
+Tracks every deployment with:
+- Unit name and dimensions
+- Git SHAs (unit, inventory, dims)
+- Terraform command and exit code
+- Timestamp and job info
+- Optional extended log data
+
+## CLI Interface
+
+```bash
+# Configuration
+cubtera config                    # Show current config
+
+# Inventory Management
+cubtera im getAll <dim_type>      # List dimension names
+cubtera im getByName <type> <name># Get dimension data
+cubtera im getDefaults <type>     # Get defaults for type
+cubtera im getByParent <type> <name>  # Get children
+cubtera im getParent <type> <name>    # Get parent
+cubtera im getOrgs                # List organizations
+cubtera im validate <type> <name> # Validate dimension
+
+# Run Units
+cubtera run -u <unit_name> -d <dim:value> [-d <dim:value>...] [-- <command>]
+cubtera tf -u network -d dome:prod -d env:prod -d dc:us-east-1 -- plan
+
+# Deployment Logs
+cubtera log get -q <key:value> [-l <limit>]
+```
+
+## API Interface
+
+```
+GET  /health                        # Health check
+GET  /v1/orgs                       # List organizations
+GET  /v1/{org}/dimTypes             # List dimension types
+GET  /v1/{org}/dims?type=           # List dims by type
+GET  /v1/{org}/dim?type=&name=      # Get dimension by name
+GET  /v1/{org}/dimDefaults?type=    # Get defaults
+GET  /v1/{org}/dimParent?type=&name=    # Get parent
+GET  /v1/{org}/dimsByParent?type=&name= # Get children
+GET  /v1/{org}/dimsData?type=       # Get all data by type
+```
+
+**Response Format:**
+```json
+{
+  "status": "ok",
+  "id": "dimByName",
+  "type": "env",
+  "name": "prod",
+  "data": { ... }
+}
+```
+
+## Data Storage
+
+### Filesystem (Storage::FS)
+
+```
+inventory/
+└── {org}/
+    ├── {dim_type}/
+    │   ├── {dim_name}.json
+    │   └── .defaults:{name}.json
+    └── ...
+```
+
+### MongoDB (Storage::DB)
+
+- Database per organization
+- Collection per dimension type
+- Documents with `name`, optional `context` field
+
+## Key Patterns
+
+### Error Handling
+
+```rust
+use crate::utils::helper::*;
+
+// Exit on error
+value.unwrap_or_exit("Error message".to_string());
+
+// Log warning and continue
+result.check_with_warn("Warning message");
+```
+
+### Handlebars Templating
+
+State backend configs support templating:
+```toml
+[state.s3]
+bucket = "{{ org }}-tfstate"
+key = "{{ dim_tree }}/{{ unit_name }}.tfstate"
+region = "us-east-1"
+```
+
+Available variables: `org`, `unit_name`, `dim_tree`
+
+### Dimension Relations
+
+Configured via `dim_relations` (colon-separated):
+```toml
+dim_relations = "dome:env:dc"
+```
+
+This defines the hierarchy: `dome` → `env` → `dc`
+
+## Testing
+
+### Run All Tests
+```bash
+cargo test
+```
+
+### Test Coverage Summary
+
+| Module | Tests | Focus |
+|--------|-------|-------|
+| `core::cfg` | 20 | Config defaults, paths, serialization |
+| `core::unit::manifest` | 24 | TOML parsing, validation |
+| `core::unit` | 17 | Unit state path, dimensions |
+| `core::runner` | 12 | Runner types, templating |
+| `core::runner::params` | 14 | Params initialization |
+| `core::dlog` | 14 | Log serialization |
+| `core::im` | 22 | Dot notation, filters |
+| `core::dim` | 14 | Dimension building |
+| `core::dim::data` | 31 | Storage, DataSource |
+| CLI integration | 31 | All CLI commands |
+| API integration | 22 | Endpoints, formats |
+
+### Test Fixtures
+
+The `example/` directory contains test fixtures:
+- `config.toml` - Example configuration
+- `inventory/cubtera/` - Sample dimensions
+- `units/` - Sample unit manifests
+
+## Development Guidelines
+
+### Adding a New Runner
+
+1. Create `runner/{type}/mod.rs`
+2. Implement `Runner` trait
+3. Add to `RunnerType` enum in `runner/mod.rs`
+4. Update `runner_create()` function
+
+### Adding a New Dimension Operation
+
+1. Add function in `core/im/mod.rs`
+2. Add CLI subcommand in `bin/cli/cmd/im_command.rs`
+3. Add API endpoint in `bin/api/api.rs`
+4. Add tests
+
+### Configuration Changes
+
+1. Add field to `CubteraConfig` in `core/cfg/mod.rs`
+2. Add default function if needed
+3. Update `Default` implementation
+4. Add tests
+
+## Dependencies
+
+Key crates:
+- `clap` - CLI argument parsing
+- `config` - Configuration loading
+- `rocket` - HTTP API framework
+- `mongodb` - MongoDB driver
+- `serde` / `serde_json` / `toml` - Serialization
+- `handlebars` - Templating
+- `git2` - Git operations for SHA retrieval
+- `walkdir` - Directory traversal
+
+Dev dependencies:
+- `assert_cmd` - CLI testing
+- `predicates` - Assertion helpers
+- `tempfile` - Temporary directories for tests
+- `mockall` - Mocking (available but not heavily used)
+
+## Common Tasks
+
+### Get dimension data programmatically
+```rust
+use cubtera::prelude::*;
+
+let dim = DimBuilder::new("env", "cubtera", &Storage::FS)
+    .with_name("prod")
+    .full_build();
+
+let data = dim.get_dim_data();
+```
+
+### Create a unit and run it
+```rust
+let unit = Unit::new(
+    "network".to_string(),
+    &["dome:prod", "env:prod", "dc:us-east-1"],
+    &[],
+    &Storage::FS,
+    None
+).build();
+
+let runner = RunnerBuilder::new(unit, vec!["plan".to_string()]).build();
+runner.run()?;
+```
+
+### Query deployment logs
+```rust
+let logs = get_dlog_by_keys(
+    "cubtera",
+    vec!["env:prod".to_string(), "dc:us-east-1".to_string()],
+    Some(10)
+);
+```
+
+## Notes for AI Agents
+
+1. **Always check GLOBAL_CFG** - Many operations depend on global config
+2. **Storage type matters** - FS vs DB affects data source behavior
+3. **Dimension hierarchy** - Parent relationships are crucial
+4. **Exit vs Error** - Code often uses `exit_with_error()` for fatal errors
+5. **Test fixtures** - Use `example/` directory for testing
+6. **MongoDB optional** - Most features work with FS storage
+7. **Context parameter** - Used for branching/PR-specific dimension data
+

--- a/src/core/dim/data/mod.rs
+++ b/src/core/dim/data/mod.rs
@@ -123,3 +123,343 @@ pub fn data_src_init(org: &str, dim_type: &str, storage: Storage) -> Box<dyn Dat
 //         }
 //     }
 // }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // ========== Storage Enum Tests ==========
+
+    #[test]
+    fn test_storage_default() {
+        let storage = Storage::default();
+        assert_eq!(storage, Storage::FS);
+    }
+
+    #[test]
+    fn test_storage_from_str_fs() {
+        let storage = Storage::from_str("fs");
+        assert_eq!(storage, Storage::FS);
+    }
+
+    #[test]
+    fn test_storage_from_str_db() {
+        let storage = Storage::from_str("db");
+        assert_eq!(storage, Storage::DB);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unknown storage type")]
+    fn test_storage_from_str_unknown() {
+        Storage::from_str("unknown");
+    }
+
+    #[test]
+    fn test_storage_to_str_fs() {
+        let storage = Storage::FS;
+        assert_eq!(storage.to_str(), "fs");
+    }
+
+    #[test]
+    fn test_storage_to_str_db() {
+        let storage = Storage::DB;
+        assert_eq!(storage.to_str(), "db");
+    }
+
+    #[test]
+    fn test_storage_get_defaults_prefix_fs() {
+        let storage = Storage::FS;
+        assert_eq!(storage.get_defaults_prefix(), ".defaults:");
+    }
+
+    #[test]
+    fn test_storage_get_defaults_prefix_db() {
+        let storage = Storage::DB;
+        assert_eq!(storage.get_defaults_prefix(), "_defaults:");
+    }
+
+    #[test]
+    fn test_storage_clone() {
+        let storage = Storage::DB;
+        let cloned = storage.clone();
+        assert_eq!(storage, cloned);
+    }
+
+    #[test]
+    fn test_storage_debug() {
+        let storage = Storage::FS;
+        let debug_str = format!("{:?}", storage);
+        assert_eq!(debug_str, "FS");
+    }
+
+    #[test]
+    fn test_storage_equality() {
+        assert_eq!(Storage::FS, Storage::FS);
+        assert_eq!(Storage::DB, Storage::DB);
+        assert_ne!(Storage::FS, Storage::DB);
+    }
+
+    // ========== Mock DataSource for Testing Default Implementations ==========
+
+    #[derive(Clone)]
+    struct MockDataSource {
+        context: Option<String>,
+    }
+
+    impl MockDataSource {
+        fn new() -> Self {
+            Self { context: None }
+        }
+    }
+
+    impl DataSource for MockDataSource {
+        fn get_data_by_name(&self, _name: &str) -> Result<Value, Box<dyn std::error::Error>> {
+            Ok(json!({"test": "data"}))
+        }
+
+        fn get_all_data(&self) -> Result<Vec<Value>, Box<dyn std::error::Error>> {
+            Ok(vec![json!({"name": "test1"}), json!({"name": "test2"})])
+        }
+
+        fn get_all_names(&self) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+            Ok(vec!["test1".to_string(), "test2".to_string()])
+        }
+
+        fn get_all_types(&self) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+            Ok(vec!["env".to_string(), "dc".to_string()])
+        }
+
+        fn set_context(&mut self, context: Option<String>) {
+            self.context = context;
+        }
+
+        fn get_context(&self) -> Option<String> {
+            self.context.clone()
+        }
+    }
+
+    // ========== DataSource Trait Default Implementation Tests ==========
+
+    #[test]
+    fn test_datasource_upsert_all_data_default() {
+        let ds = MockDataSource::new();
+        let data = vec![json!({"name": "test"})];
+        let result = ds.upsert_all_data(data);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_datasource_upsert_data_by_name_default() {
+        let ds = MockDataSource::new();
+        let result = ds.upsert_data_by_name("test", json!({"data": "value"}));
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_datasource_delete_data_by_name_default() {
+        let ds = MockDataSource::new();
+        let result = ds.delete_data_by_name("test");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_datasource_delete_all_by_context_default() {
+        let ds = MockDataSource::new();
+        let result = ds.delete_all_by_context("test_context");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_datasource_context_management() {
+        let mut ds = MockDataSource::new();
+
+        // Initially no context
+        assert!(ds.get_context().is_none());
+
+        // Set context
+        ds.set_context(Some("branch:feature-1".to_string()));
+        assert_eq!(ds.get_context(), Some("branch:feature-1".to_string()));
+
+        // Clear context
+        ds.set_context(None);
+        assert!(ds.get_context().is_none());
+    }
+
+    #[test]
+    fn test_datasource_get_data_by_name() {
+        let ds = MockDataSource::new();
+        let result = ds.get_data_by_name("test");
+
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data["test"], "data");
+    }
+
+    #[test]
+    fn test_datasource_get_all_data() {
+        let ds = MockDataSource::new();
+        let result = ds.get_all_data();
+
+        assert!(result.is_ok());
+        let data = result.unwrap();
+        assert_eq!(data.len(), 2);
+    }
+
+    #[test]
+    fn test_datasource_get_all_names() {
+        let ds = MockDataSource::new();
+        let result = ds.get_all_names();
+
+        assert!(result.is_ok());
+        let names = result.unwrap();
+        assert!(names.contains(&"test1".to_string()));
+        assert!(names.contains(&"test2".to_string()));
+    }
+
+    #[test]
+    fn test_datasource_get_all_types() {
+        let ds = MockDataSource::new();
+        let result = ds.get_all_types();
+
+        assert!(result.is_ok());
+        let types = result.unwrap();
+        assert!(types.contains(&"env".to_string()));
+        assert!(types.contains(&"dc".to_string()));
+    }
+
+    // ========== CloneBox Trait Tests ==========
+
+    #[test]
+    fn test_clone_box() {
+        let ds = MockDataSource::new();
+        let boxed: Box<dyn DataSource> = Box::new(ds);
+        let cloned = boxed.clone_box();
+
+        // Verify the cloned datasource works
+        let result = cloned.get_all_names();
+        assert!(result.is_ok());
+    }
+
+    // ========== BSON/JSON Conversion Simulation Tests ==========
+    // These test the patterns used in MongoDB operations without actual MongoDB
+
+    #[test]
+    fn test_json_to_bson_conversion() {
+        use ::mongodb::bson;
+
+        let json_value = json!({
+            "name": "test-dim",
+            "type": "env",
+            "data": {
+                "key1": "value1",
+                "key2": 42
+            }
+        });
+
+        // Simulate BSON conversion
+        let bson_val = bson::to_bson(&json_value);
+        assert!(bson_val.is_ok());
+
+        // Convert back
+        let back: Result<Value, _> = bson::from_bson(bson_val.unwrap());
+        assert!(back.is_ok());
+
+        let restored = back.unwrap();
+        assert_eq!(restored["name"], "test-dim");
+        assert_eq!(restored["type"], "env");
+        assert_eq!(restored["data"]["key1"], "value1");
+        assert_eq!(restored["data"]["key2"], 42);
+    }
+
+    #[test]
+    fn test_json_to_bson_document() {
+        use ::mongodb::bson;
+
+        let json_value = json!({
+            "name": "test",
+            "context": "branch:feature"
+        });
+
+        let doc = bson::to_document(&json_value);
+        assert!(doc.is_ok());
+
+        let doc = doc.unwrap();
+        assert_eq!(doc.get_str("name"), Ok("test"));
+        assert_eq!(doc.get_str("context"), Ok("branch:feature"));
+    }
+
+    #[test]
+    fn test_bson_doc_filter_pattern() {
+        use ::mongodb::bson::doc;
+
+        // Test patterns used in MongoDB queries
+        let filter_by_name = doc! { "name": "test-name" };
+        assert!(filter_by_name.contains_key("name"));
+
+        let filter_with_context = doc! { "name": "test", "context": "branch:feature" };
+        assert!(filter_with_context.contains_key("context"));
+
+        let filter_no_context = doc! { "name": "test", "context": { "$exists": false }};
+        assert!(filter_no_context.contains_key("name"));
+        assert!(filter_no_context.contains_key("context"));
+    }
+
+    #[test]
+    fn test_data_manipulation_pattern() {
+        // Test pattern for manipulating data before BSON conversion
+        let mut data = json!({
+            "name": "test",
+            "value": 42
+        });
+
+        // Add context like MongoDB operations do
+        data["context"] = json!("branch:feature");
+
+        assert_eq!(data["name"], "test");
+        assert_eq!(data["value"], 42);
+        assert_eq!(data["context"], "branch:feature");
+
+        // Remove _id field pattern
+        data.as_object_mut().unwrap().remove("_id");
+        assert!(data.get("_id").is_none());
+    }
+
+    #[test]
+    fn test_defaults_name_pattern() {
+        let name = "_defaults:global";
+
+        // Test the pattern for checking defaults
+        assert!(name.starts_with("_defaults:"));
+
+        let name = ".defaults:global";
+        assert!(name.starts_with(".defaults:"));
+
+        let name = "regular-name";
+        assert!(!name.starts_with("_defaults:"));
+        assert!(!name.starts_with(".defaults:"));
+    }
+
+    #[test]
+    fn test_context_filter_patterns() {
+        // Test various context filter patterns
+        let context = Some("branch:feature".to_string());
+
+        // Pattern 1: Check if context exists and is not empty
+        if let Some(ctx) = &context {
+            if !ctx.is_empty() {
+                assert_eq!(ctx, "branch:feature");
+            }
+        }
+
+        // Pattern 2: No context
+        let no_context: Option<String> = None;
+        assert!(no_context.is_none());
+
+        // Pattern 3: Empty context
+        let empty_context = Some("".to_string());
+        if let Some(ctx) = &empty_context {
+            assert!(ctx.is_empty());
+        }
+    }
+}

--- a/src/core/dlog/mod.rs
+++ b/src/core/dlog/mod.rs
@@ -158,3 +158,269 @@ fn get_extended_log() -> Option<HashMap<String, String>> {
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    // Helper to create a minimal Dlog for testing
+    fn create_test_dlog() -> Dlog {
+        let mut dims: HashMap<String, String> = HashMap::new();
+        dims.insert("env".to_string(), "prod".to_string());
+        dims.insert("dc".to_string(), "us-east-1".to_string());
+
+        let mut dims_blob_sha: HashMap<String, String> = HashMap::new();
+        dims_blob_sha.insert("env:prod".to_string(), "sha1".to_string());
+        dims_blob_sha.insert("dc:us-east-1".to_string(), "sha2".to_string());
+
+        Dlog {
+            unit_name: Some("network".to_string()),
+            state_path: Some("env:prod/dc:us-east-1".to_string()),
+            dims: Some(dims),
+            job_host_name: Some("localhost".to_string()),
+            job_user_name: Some("testuser".to_string()),
+            job_number: Some("123".to_string()),
+            job_name: Some("deploy-network".to_string()),
+            tf_command: Some("apply".to_string()),
+            exitcode: Some(0),
+            unit_sha: Some("abc123".to_string()),
+            unit_blob_sha: Some("def456".to_string()),
+            inventory_sha: Some("ghi789".to_string()),
+            dims_blob_sha: Some(dims_blob_sha),
+            env_vars: None,
+            timestamp: Some(1704067200), // 2024-01-01 00:00:00 UTC
+            datetime: Some("2024-01-01 00:00:00 UTC".to_string()),
+            extended_log: None,
+        }
+    }
+
+    #[test]
+    fn test_dlog_serialization() {
+        let dlog = create_test_dlog();
+
+        let json = serde_json::to_string(&dlog).unwrap();
+
+        assert!(json.contains("network"));
+        assert!(json.contains("env:prod/dc:us-east-1"));
+        assert!(json.contains("apply"));
+        assert!(json.contains("testuser"));
+    }
+
+    #[test]
+    fn test_dlog_deserialization() {
+        let json = r#"{
+            "unit_name": "network",
+            "state_path": "env:prod/dc:us-east-1",
+            "tf_command": "apply",
+            "exitcode": 0,
+            "timestamp": 1704067200
+        }"#;
+
+        let dlog: Dlog = serde_json::from_str(json).unwrap();
+
+        assert_eq!(dlog.unit_name, Some("network".to_string()));
+        assert_eq!(dlog.state_path, Some("env:prod/dc:us-east-1".to_string()));
+        assert_eq!(dlog.tf_command, Some("apply".to_string()));
+        assert_eq!(dlog.exitcode, Some(0));
+        assert_eq!(dlog.timestamp, Some(1704067200));
+    }
+
+    #[test]
+    fn test_dlog_serialization_skips_none_fields() {
+        let dlog = Dlog {
+            unit_name: Some("test".to_string()),
+            state_path: None,
+            dims: None,
+            job_host_name: None,
+            job_user_name: None,
+            job_number: None,
+            job_name: None,
+            tf_command: None,
+            exitcode: None,
+            unit_sha: None,
+            unit_blob_sha: None,
+            inventory_sha: None,
+            dims_blob_sha: None,
+            env_vars: None,
+            timestamp: None,
+            datetime: None,
+            extended_log: None,
+        };
+
+        let json = serde_json::to_string(&dlog).unwrap();
+
+        // None fields should not be in the JSON output
+        assert!(!json.contains("state_path"));
+        assert!(!json.contains("job_host_name"));
+        assert!(!json.contains("tf_command"));
+        assert!(json.contains("unit_name"));
+    }
+
+    #[test]
+    fn test_dlog_clone() {
+        let dlog = create_test_dlog();
+        let cloned = dlog.clone();
+
+        assert_eq!(dlog.unit_name, cloned.unit_name);
+        assert_eq!(dlog.state_path, cloned.state_path);
+        assert_eq!(dlog.exitcode, cloned.exitcode);
+        assert_eq!(dlog.tf_command, cloned.tf_command);
+    }
+
+    #[test]
+    fn test_dlog_debug() {
+        let dlog = create_test_dlog();
+        let debug_str = format!("{:?}", dlog);
+
+        assert!(debug_str.contains("Dlog"));
+        assert!(debug_str.contains("network"));
+    }
+
+    #[test]
+    fn test_dlog_roundtrip() {
+        let original = create_test_dlog();
+
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: Dlog = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(original.unit_name, restored.unit_name);
+        assert_eq!(original.state_path, restored.state_path);
+        assert_eq!(original.dims, restored.dims);
+        assert_eq!(original.job_host_name, restored.job_host_name);
+        assert_eq!(original.job_user_name, restored.job_user_name);
+        assert_eq!(original.job_number, restored.job_number);
+        assert_eq!(original.job_name, restored.job_name);
+        assert_eq!(original.tf_command, restored.tf_command);
+        assert_eq!(original.exitcode, restored.exitcode);
+        assert_eq!(original.timestamp, restored.timestamp);
+    }
+
+    #[test]
+    fn test_dlog_with_env_vars() {
+        let mut env_vars: HashMap<String, String> = HashMap::new();
+        env_vars.insert("AWS_REGION".to_string(), "us-east-1".to_string());
+        env_vars.insert("TF_VAR_env".to_string(), "prod".to_string());
+
+        let mut dlog = create_test_dlog();
+        dlog.env_vars = Some(env_vars);
+
+        let json = serde_json::to_string(&dlog).unwrap();
+
+        assert!(json.contains("AWS_REGION"));
+        assert!(json.contains("us-east-1"));
+        assert!(json.contains("TF_VAR_env"));
+    }
+
+    #[test]
+    fn test_dlog_with_extended_log() {
+        let mut extended_log: HashMap<String, String> = HashMap::new();
+        extended_log.insert("plan_output".to_string(), "No changes".to_string());
+        extended_log.insert("duration".to_string(), "120s".to_string());
+
+        let mut dlog = create_test_dlog();
+        dlog.extended_log = Some(extended_log);
+
+        let json = serde_json::to_string(&dlog).unwrap();
+
+        assert!(json.contains("plan_output"));
+        assert!(json.contains("No changes"));
+        assert!(json.contains("duration"));
+    }
+
+    #[test]
+    fn test_dlog_exitcode_values() {
+        let mut dlog = create_test_dlog();
+
+        // Success
+        dlog.exitcode = Some(0);
+        let json = serde_json::to_string(&dlog).unwrap();
+        assert!(json.contains("\"exitcode\":0"));
+
+        // Failure
+        dlog.exitcode = Some(1);
+        let json = serde_json::to_string(&dlog).unwrap();
+        assert!(json.contains("\"exitcode\":1"));
+
+        // Other exit codes
+        dlog.exitcode = Some(2);
+        let json = serde_json::to_string(&dlog).unwrap();
+        assert!(json.contains("\"exitcode\":2"));
+    }
+
+    #[test]
+    fn test_dlog_tf_commands() {
+        let commands = vec!["plan", "apply", "destroy", "init", "refresh"];
+
+        for cmd in commands {
+            let mut dlog = create_test_dlog();
+            dlog.tf_command = Some(cmd.to_string());
+
+            let json = serde_json::to_string(&dlog).unwrap();
+            assert!(json.contains(cmd));
+        }
+    }
+
+    #[test]
+    fn test_dlog_dims_parsing() {
+        let dlog = create_test_dlog();
+
+        let dims = dlog.dims.unwrap();
+        assert_eq!(dims.get("env"), Some(&"prod".to_string()));
+        assert_eq!(dims.get("dc"), Some(&"us-east-1".to_string()));
+    }
+
+    #[test]
+    fn test_dlog_to_json_value() {
+        let dlog = create_test_dlog();
+
+        let value: Value = serde_json::to_value(&dlog).unwrap();
+
+        assert!(value.is_object());
+        assert_eq!(value["unit_name"], "network");
+        assert_eq!(value["tf_command"], "apply");
+        assert_eq!(value["exitcode"], 0);
+    }
+
+    #[test]
+    fn test_dims_extraction_from_state_path() {
+        // Simulating what Dlog::build does
+        let state_path = "dome:prod/env:production/dc:us-east-1";
+        let dims: HashMap<String, String> = state_path
+            .split('/')
+            .map(Into::into)
+            .map(|dim: String| {
+                let parts: Vec<&str> = dim.split(':').collect();
+                (parts[0].to_string(), parts[1].to_string())
+            })
+            .collect();
+
+        assert_eq!(dims.len(), 3);
+        assert_eq!(dims.get("dome"), Some(&"prod".to_string()));
+        assert_eq!(dims.get("env"), Some(&"production".to_string()));
+        assert_eq!(dims.get("dc"), Some(&"us-east-1".to_string()));
+    }
+
+    #[test]
+    fn test_dlog_deserialization_from_bson_compatible_json() {
+        // Test that Dlog can deserialize from JSON that might come from MongoDB
+        let json = json!({
+            "unit_name": "test-unit",
+            "state_path": "env:staging/dc:eu-west-1",
+            "dims": {
+                "env": "staging",
+                "dc": "eu-west-1"
+            },
+            "tf_command": "plan",
+            "exitcode": 0,
+            "timestamp": 1704067200,
+            "datetime": "2024-01-01T00:00:00Z"
+        });
+
+        let dlog: Dlog = serde_json::from_value(json).unwrap();
+
+        assert_eq!(dlog.unit_name, Some("test-unit".to_string()));
+        assert_eq!(dlog.tf_command, Some("plan".to_string()));
+        assert_eq!(dlog.dims.as_ref().unwrap().get("env"), Some(&"staging".to_string()));
+    }
+}

--- a/src/core/im/mod.rs
+++ b/src/core/im/mod.rs
@@ -220,6 +220,382 @@ fn to_dot_notation(value: &Value, prefix: String) -> HashMap<String, Value> {
     result
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Tests for to_dot_notation helper function
+    #[test]
+    fn test_to_dot_notation_flat_object() {
+        let value = json!({
+            "env": "prod",
+            "dc": "us-east-1"
+        });
+
+        let result = to_dot_notation(&value, String::new());
+
+        assert_eq!(result.get("env"), Some(&json!("prod")));
+        assert_eq!(result.get("dc"), Some(&json!("us-east-1")));
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_to_dot_notation_nested_object() {
+        let value = json!({
+            "dims": {
+                "env": "prod",
+                "dc": "us-east-1"
+            }
+        });
+
+        let result = to_dot_notation(&value, String::new());
+
+        assert_eq!(result.get("dims.env"), Some(&json!("prod")));
+        assert_eq!(result.get("dims.dc"), Some(&json!("us-east-1")));
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn test_to_dot_notation_deeply_nested() {
+        let value = json!({
+            "level1": {
+                "level2": {
+                    "level3": "value"
+                }
+            }
+        });
+
+        let result = to_dot_notation(&value, String::new());
+
+        assert_eq!(result.get("level1.level2.level3"), Some(&json!("value")));
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_to_dot_notation_mixed_types() {
+        let value = json!({
+            "string": "value",
+            "number": 42,
+            "boolean": true,
+            "nested": {
+                "inner": "data"
+            }
+        });
+
+        let result = to_dot_notation(&value, String::new());
+
+        assert_eq!(result.get("string"), Some(&json!("value")));
+        assert_eq!(result.get("number"), Some(&json!(42)));
+        assert_eq!(result.get("boolean"), Some(&json!(true)));
+        assert_eq!(result.get("nested.inner"), Some(&json!("data")));
+        assert_eq!(result.len(), 4);
+    }
+
+    #[test]
+    fn test_to_dot_notation_with_prefix() {
+        let value = json!({
+            "key": "value"
+        });
+
+        let result = to_dot_notation(&value, "prefix".to_string());
+
+        assert_eq!(result.get("prefix.key"), Some(&json!("value")));
+    }
+
+    #[test]
+    fn test_to_dot_notation_empty_object() {
+        let value = json!({});
+
+        let result = to_dot_notation(&value, String::new());
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_to_dot_notation_non_object() {
+        let value = json!("string");
+
+        let result = to_dot_notation(&value, String::new());
+
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_to_dot_notation_array_not_expanded() {
+        let value = json!({
+            "array": [1, 2, 3]
+        });
+
+        let result = to_dot_notation(&value, String::new());
+
+        // Arrays should be kept as-is, not expanded
+        assert_eq!(result.get("array"), Some(&json!([1, 2, 3])));
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_to_dot_notation_mongodb_query_style() {
+        // Test case similar to what would be used for MongoDB queries
+        let value = json!({
+            "dims": {
+                "env": "prod",
+                "dc": "us-east-1"
+            },
+            "tf_command": "apply"
+        });
+
+        let result = to_dot_notation(&value, String::new());
+
+        assert_eq!(result.get("dims.env"), Some(&json!("prod")));
+        assert_eq!(result.get("dims.dc"), Some(&json!("us-east-1")));
+        assert_eq!(result.get("tf_command"), Some(&json!("apply")));
+    }
+
+    // Tests for response format validation
+    #[test]
+    fn test_response_format_dim_by_name() {
+        // Verify the expected JSON structure for dim_by_name responses
+        let expected_fields = vec!["status", "id", "type", "name", "data"];
+
+        let response = json!({
+            "status": "ok",
+            "id": "dimByName",
+            "type": "env",
+            "name": "prod",
+            "data": {}
+        });
+
+        for field in expected_fields {
+            assert!(response.get(field).is_some(), "Missing field: {}", field);
+        }
+        assert_eq!(response["id"], "dimByName");
+    }
+
+    #[test]
+    fn test_response_format_dims_by_type() {
+        let expected_fields = vec!["status", "id", "type", "data"];
+
+        let response = json!({
+            "status": "ok",
+            "id": "dimsByType",
+            "type": "env",
+            "data": ["prod", "staging", "dev"]
+        });
+
+        for field in expected_fields {
+            assert!(response.get(field).is_some(), "Missing field: {}", field);
+        }
+        assert_eq!(response["id"], "dimsByType");
+    }
+
+    #[test]
+    fn test_response_format_dims_data_by_type() {
+        let expected_fields = vec!["status", "id", "type", "data"];
+
+        let response = json!({
+            "status": "ok",
+            "id": "dimsDataByType",
+            "type": "env",
+            "data": []
+        });
+
+        for field in expected_fields {
+            assert!(response.get(field).is_some(), "Missing field: {}", field);
+        }
+        assert_eq!(response["id"], "dimsDataByType");
+    }
+
+    #[test]
+    fn test_response_format_dims_defaults_by_type() {
+        let expected_fields = vec!["status", "id", "type", "data"];
+
+        let response = json!({
+            "status": "ok",
+            "id": "dimsDefaultsByType",
+            "type": "env",
+            "data": {}
+        });
+
+        for field in expected_fields {
+            assert!(response.get(field).is_some(), "Missing field: {}", field);
+        }
+        assert_eq!(response["id"], "dimsDefaultsByType");
+    }
+
+    #[test]
+    fn test_response_format_dims_by_parent() {
+        let expected_fields = vec!["status", "id", "parent_type", "parent_name", "data"];
+
+        let response = json!({
+            "status": "ok",
+            "id": "dimsByParent",
+            "parent_type": "env",
+            "parent_name": "prod",
+            "data": {
+                "dim_type": "dc",
+                "dim_names": ["us-east-1", "us-west-2"]
+            }
+        });
+
+        for field in expected_fields {
+            assert!(response.get(field).is_some(), "Missing field: {}", field);
+        }
+        assert_eq!(response["id"], "dimsByParent");
+    }
+
+    #[test]
+    fn test_response_format_dim_parent() {
+        let expected_fields = vec!["status", "id", "type", "name", "data"];
+
+        let response = json!({
+            "status": "ok",
+            "id": "dimParent",
+            "type": "dome",
+            "name": "prod",
+            "data": {}
+        });
+
+        for field in expected_fields {
+            assert!(response.get(field).is_some(), "Missing field: {}", field);
+        }
+        assert_eq!(response["id"], "dimParent");
+    }
+
+    #[test]
+    fn test_response_format_orgs() {
+        let expected_fields = vec!["status", "id", "data"];
+
+        let response = json!({
+            "status": "ok",
+            "id": "orgs",
+            "data": ["cubtera", "myorg"]
+        });
+
+        for field in expected_fields {
+            assert!(response.get(field).is_some(), "Missing field: {}", field);
+        }
+        assert_eq!(response["id"], "orgs");
+    }
+
+    #[test]
+    fn test_response_format_dlog() {
+        let expected_fields = vec!["status", "id", "data", "limit", "filter"];
+
+        let response = json!({
+            "status": "ok",
+            "id": "dlog",
+            "data": [],
+            "limit": 10,
+            "filter": {}
+        });
+
+        for field in expected_fields {
+            assert!(response.get(field).is_some(), "Missing field: {}", field);
+        }
+        assert_eq!(response["id"], "dlog");
+    }
+
+    #[test]
+    fn test_response_format_dim_types() {
+        let expected_fields = vec!["status", "id", "org", "data"];
+
+        let response = json!({
+            "status": "ok",
+            "id": "dimTypes",
+            "org": "cubtera",
+            "data": ["dome", "env", "dc"]
+        });
+
+        for field in expected_fields {
+            assert!(response.get(field).is_some(), "Missing field: {}", field);
+        }
+        assert_eq!(response["id"], "dimTypes");
+    }
+
+    #[test]
+    fn test_response_format_error() {
+        let expected_fields = vec!["status", "id", "message", "data"];
+
+        let response = json!({
+            "status": "error",
+            "id": "dimParent",
+            "message": "No parent dim found",
+            "data": null
+        });
+
+        for field in expected_fields {
+            assert!(response.get(field).is_some(), "Missing field: {}", field);
+        }
+        assert_eq!(response["status"], "error");
+    }
+
+    // Test get_dlog_by_keys key parsing
+    #[test]
+    fn test_keys_parsing() {
+        let keys = vec!["env:prod".to_string(), "dc:us-east-1".to_string()];
+
+        let parsed: HashMap<String, String> = keys
+            .iter()
+            .map(|dim: &String| {
+                let parts: Vec<&str> = dim.split(':').collect();
+                (parts[0].to_string(), parts[1].to_string())
+            })
+            .collect();
+
+        assert_eq!(parsed.get("env"), Some(&"prod".to_string()));
+        assert_eq!(parsed.get("dc"), Some(&"us-east-1".to_string()));
+    }
+
+    #[test]
+    fn test_orgs_filter_system_databases() {
+        let orgs = vec![
+            "cubtera".to_string(),
+            "admin".to_string(),
+            "local".to_string(),
+            "config".to_string(),
+            "test".to_string(),
+            "myorg".to_string(),
+        ];
+
+        let filtered: Vec<String> = orgs
+            .iter()
+            .map(String::as_ref)
+            .filter(|dim| !["admin", "local", "config", "test"].contains(dim))
+            .map(|dim| dim.to_string())
+            .collect();
+
+        assert_eq!(filtered, vec!["cubtera", "myorg"]);
+        assert!(!filtered.contains(&"admin".to_string()));
+        assert!(!filtered.contains(&"local".to_string()));
+        assert!(!filtered.contains(&"config".to_string()));
+        assert!(!filtered.contains(&"test".to_string()));
+    }
+
+    #[test]
+    fn test_dim_types_filter_system_collections() {
+        let collections = vec![
+            "dome".to_string(),
+            "env".to_string(),
+            "dc".to_string(),
+            "defaults".to_string(),
+            "log".to_string(),
+            "dlog".to_string(),
+        ];
+
+        let filtered: Vec<String> = collections
+            .iter()
+            .map(String::as_ref)
+            .filter(|dim| !["defaults", "log", "dlog"].contains(dim))
+            .map(|dim| dim.to_string())
+            .collect();
+
+        assert_eq!(filtered, vec!["dome", "env", "dc"]);
+        assert!(!filtered.contains(&"defaults".to_string()));
+        assert!(!filtered.contains(&"log".to_string()));
+        assert!(!filtered.contains(&"dlog".to_string()));
+    }
+}
+
 pub fn get_all_dim_types(org: &str, storage: &Storage) -> Value {
     let dim_types = match storage {
         Storage::DB => {

--- a/src/core/runner/params.rs
+++ b/src/core/runner/params.rs
@@ -58,3 +58,200 @@ fn default_version() -> String {
 fn default_state_backend() -> String {
     String::from("local")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper to create params with serde defaults applied (via init from empty hashmap)
+    fn create_params_with_defaults() -> RunnerParams {
+        RunnerParams::init(HashMap::new())
+    }
+
+    #[test]
+    fn test_rust_default_values() {
+        // Rust's Default trait gives empty strings, not serde defaults
+        let params = RunnerParams::default();
+
+        // These will be empty strings due to Rust's Default, not serde defaults
+        assert_eq!(params.version, "");
+        assert_eq!(params.state_backend, "");
+        assert_eq!(params.lock_port, "");
+        assert!(params.runner_command.is_none());
+        assert!(params.extra_args.is_none());
+        assert!(params.inlet_command.is_none());
+        assert!(params.outlet_command.is_none());
+    }
+
+    #[test]
+    fn test_serde_default_values() {
+        // Serde defaults are applied during deserialization
+        let params = create_params_with_defaults();
+
+        assert_eq!(params.version, "latest");
+        assert_eq!(params.state_backend, "local");
+        assert_eq!(params.lock_port, "65432");
+        assert!(params.runner_command.is_none());
+        assert!(params.extra_args.is_none());
+        assert!(params.inlet_command.is_none());
+        assert!(params.outlet_command.is_none());
+    }
+
+    #[test]
+    fn test_init_from_empty_hashmap() {
+        let params_map: HashMap<String, String> = HashMap::new();
+        let params = RunnerParams::init(params_map);
+
+        assert_eq!(params.version, "latest");
+        assert_eq!(params.state_backend, "local");
+        assert_eq!(params.lock_port, "65432");
+    }
+
+    #[test]
+    fn test_init_from_hashmap_with_values() {
+        let mut params_map: HashMap<String, String> = HashMap::new();
+        params_map.insert("version".to_string(), "1.5.0".to_string());
+        params_map.insert("state_backend".to_string(), "s3".to_string());
+        params_map.insert("lock_port".to_string(), "12345".to_string());
+        params_map.insert("runner_command".to_string(), "terraform".to_string());
+        params_map.insert("extra_args".to_string(), "-json".to_string());
+        params_map.insert("inlet_command".to_string(), "echo inlet".to_string());
+        params_map.insert("outlet_command".to_string(), "echo outlet".to_string());
+
+        let params = RunnerParams::init(params_map);
+
+        assert_eq!(params.version, "1.5.0");
+        assert_eq!(params.state_backend, "s3");
+        assert_eq!(params.lock_port, "12345");
+        assert_eq!(params.runner_command, Some("terraform".to_string()));
+        assert_eq!(params.extra_args, Some("-json".to_string()));
+        assert_eq!(params.inlet_command, Some("echo inlet".to_string()));
+        assert_eq!(params.outlet_command, Some("echo outlet".to_string()));
+    }
+
+    #[test]
+    fn test_init_partial_hashmap() {
+        let mut params_map: HashMap<String, String> = HashMap::new();
+        params_map.insert("version".to_string(), "1.6.0".to_string());
+        // Don't set other fields
+
+        let params = RunnerParams::init(params_map);
+
+        assert_eq!(params.version, "1.6.0");
+        assert_eq!(params.state_backend, "local"); // serde default
+        assert_eq!(params.lock_port, "65432"); // serde default
+        assert!(params.runner_command.is_none());
+    }
+
+    #[test]
+    fn test_get_lock_port() {
+        let mut params = create_params_with_defaults();
+
+        // Default value (from serde)
+        assert_eq!(params.get_lock_port(), 65432);
+
+        // Custom value
+        params.lock_port = "12345".to_string();
+        assert_eq!(params.get_lock_port(), 12345);
+
+        // Invalid value should return default
+        params.lock_port = "invalid".to_string();
+        assert_eq!(params.get_lock_port(), 65432);
+
+        // Empty string should return default
+        params.lock_port = "".to_string();
+        assert_eq!(params.get_lock_port(), 65432);
+    }
+
+    #[test]
+    fn test_get_version() {
+        let mut params = create_params_with_defaults();
+        assert_eq!(params.get_version(), "latest");
+
+        params.version = "1.5.0".to_string();
+        assert_eq!(params.get_version(), "1.5.0");
+    }
+
+    #[test]
+    fn test_get_state_backend() {
+        let mut params = create_params_with_defaults();
+        assert_eq!(params.get_state_backend(), "local");
+
+        params.state_backend = "s3".to_string();
+        assert_eq!(params.get_state_backend(), "s3");
+    }
+
+    #[test]
+    fn test_get_params_hashmap() {
+        let mut params = create_params_with_defaults();
+        params.version = "1.5.0".to_string();
+        params.runner_command = Some("terraform".to_string());
+
+        let hashmap = params.get_params_hashmap();
+
+        assert_eq!(hashmap.get("version"), Some(&"1.5.0".to_string()));
+        assert_eq!(hashmap.get("state_backend"), Some(&"local".to_string()));
+        assert_eq!(hashmap.get("lock_port"), Some(&"65432".to_string()));
+        assert_eq!(hashmap.get("runner_command"), Some(&"terraform".to_string()));
+    }
+
+    #[test]
+    fn test_serialization_roundtrip() {
+        let mut params = create_params_with_defaults();
+        params.version = "1.6.0".to_string();
+        params.state_backend = "s3".to_string();
+        params.runner_command = Some("terraform".to_string());
+        params.extra_args = Some("-auto-approve".to_string());
+
+        let json = serde_json::to_string(&params).unwrap();
+        let deserialized: RunnerParams = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(params.version, deserialized.version);
+        assert_eq!(params.state_backend, deserialized.state_backend);
+        assert_eq!(params.runner_command, deserialized.runner_command);
+        assert_eq!(params.extra_args, deserialized.extra_args);
+    }
+
+    #[test]
+    fn test_deserialization_with_missing_optional_fields() {
+        let json = r#"{"version": "1.5.0", "state_backend": "s3", "lock_port": "65432"}"#;
+        let params: RunnerParams = serde_json::from_str(json).unwrap();
+
+        assert_eq!(params.version, "1.5.0");
+        assert_eq!(params.state_backend, "s3");
+        assert!(params.runner_command.is_none());
+        assert!(params.extra_args.is_none());
+        assert!(params.inlet_command.is_none());
+        assert!(params.outlet_command.is_none());
+    }
+
+    #[test]
+    fn test_deserialization_with_empty_json() {
+        // When deserializing from empty JSON, serde defaults should apply
+        let json = "{}";
+        let params: RunnerParams = serde_json::from_str(json).unwrap();
+
+        assert_eq!(params.version, "latest");
+        assert_eq!(params.state_backend, "local");
+        assert_eq!(params.lock_port, "65432");
+    }
+
+    #[test]
+    fn test_default_functions() {
+        assert_eq!(default_version(), "latest");
+        assert_eq!(default_state_backend(), "local");
+        assert_eq!(default_lock_port(), "65432");
+    }
+
+    #[test]
+    fn test_clone() {
+        let mut params = create_params_with_defaults();
+        params.version = "1.5.0".to_string();
+        params.runner_command = Some("terraform".to_string());
+
+        let cloned = params.clone();
+
+        assert_eq!(params.version, cloned.version);
+        assert_eq!(params.runner_command, cloned.runner_command);
+    }
+}

--- a/src/core/unit/manifest.rs
+++ b/src/core/unit/manifest.rs
@@ -67,3 +67,491 @@ pub struct Files {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub required: Option<HashMap<String, String>>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    fn create_manifest_file(dir: &std::path::Path, content: &str) {
+        let manifest_path = dir.join("manifest.toml");
+        let mut file = fs::File::create(manifest_path).unwrap();
+        write!(file, "{}", content).unwrap();
+    }
+
+    #[test]
+    fn test_manifest_load_basic() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env", "dc"]
+type = "tf"
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert_eq!(manifest.dimensions, vec!["env", "dc"]);
+        assert_eq!(manifest.unit_type, "tf");
+        assert!(!manifest.overwrite);
+        assert!(manifest.opt_dims.is_none());
+        assert!(manifest.allow_list.is_none());
+        assert!(manifest.deny_list.is_none());
+    }
+
+    #[test]
+    fn test_manifest_load_with_overwrite() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["dome"]
+type = "bash"
+overwrite = true
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.overwrite);
+        assert_eq!(manifest.unit_type, "bash");
+    }
+
+    #[test]
+    fn test_manifest_load_with_allow_list() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+allowList = ["prod", "staging"]
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.allow_list.is_some());
+        let allow_list = manifest.allow_list.unwrap();
+        assert_eq!(allow_list, vec!["prod", "staging"]);
+    }
+
+    #[test]
+    fn test_manifest_load_with_deny_list() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+denyList = ["dev", "test"]
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.deny_list.is_some());
+        let deny_list = manifest.deny_list.unwrap();
+        assert_eq!(deny_list, vec!["dev", "test"]);
+    }
+
+    #[test]
+    fn test_manifest_load_with_opt_dims() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+optDims = ["region", "zone"]
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.opt_dims.is_some());
+        let opt_dims = manifest.opt_dims.unwrap();
+        assert_eq!(opt_dims, vec!["region", "zone"]);
+    }
+
+    #[test]
+    fn test_manifest_load_with_affinity_tags() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+affinityTags = ["production", "critical"]
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.affinity_tags.is_some());
+        let tags = manifest.affinity_tags.unwrap();
+        assert_eq!(tags, vec!["production", "critical"]);
+    }
+
+    #[test]
+    fn test_manifest_load_with_runner_config() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+
+[runner]
+version = "1.5.0"
+state_backend = "s3"
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.runner.is_some());
+        let runner = manifest.runner.unwrap();
+        assert_eq!(runner.get("version"), Some(&"1.5.0".to_string()));
+        assert_eq!(runner.get("state_backend"), Some(&"s3".to_string()));
+    }
+
+    #[test]
+    fn test_manifest_load_with_state_config() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+
+[state]
+bucket = "my-bucket"
+region = "us-east-1"
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.state.is_some());
+        let state = manifest.state.unwrap();
+        assert_eq!(state.get("bucket"), Some(&"my-bucket".to_string()));
+        assert_eq!(state.get("region"), Some(&"us-east-1".to_string()));
+    }
+
+    #[test]
+    fn test_manifest_load_with_spec_tf_version() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+
+[spec]
+tfVersion = "1.6.0"
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.spec.is_some());
+        let spec = manifest.spec.unwrap();
+        assert_eq!(spec.tf_version, Some("1.6.0".to_string()));
+    }
+
+    #[test]
+    fn test_manifest_load_with_spec_env_vars() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+
+[spec.envVars.required]
+AWS_ACCESS_KEY_ID = "AWS_ACCESS_KEY_ID"
+AWS_SECRET_ACCESS_KEY = "AWS_SECRET_ACCESS_KEY"
+
+[spec.envVars.optional]
+AWS_SESSION_TOKEN = "AWS_SESSION_TOKEN"
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.spec.is_some());
+        let spec = manifest.spec.unwrap();
+        assert!(spec.env_vars.is_some());
+
+        let env_vars = spec.env_vars.unwrap();
+        assert!(env_vars.required.is_some());
+        assert!(env_vars.optional.is_some());
+
+        let required = env_vars.required.unwrap();
+        assert_eq!(required.get("AWS_ACCESS_KEY_ID"), Some(&"AWS_ACCESS_KEY_ID".to_string()));
+
+        let optional = env_vars.optional.unwrap();
+        assert_eq!(optional.get("AWS_SESSION_TOKEN"), Some(&"AWS_SESSION_TOKEN".to_string()));
+    }
+
+    #[test]
+    fn test_manifest_load_with_spec_files() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+
+[spec.files.required]
+"~/.ssh/id_rsa" = "id_rsa"
+
+[spec.files.optional]
+"~/.ssh/id_rsa.pub" = "id_rsa.pub"
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.spec.is_some());
+        let spec = manifest.spec.unwrap();
+        assert!(spec.files.is_some());
+
+        let files = spec.files.unwrap();
+        assert!(files.required.is_some());
+        assert!(files.optional.is_some());
+
+        let required = files.required.unwrap();
+        assert_eq!(required.get("~/.ssh/id_rsa"), Some(&"id_rsa".to_string()));
+    }
+
+    #[test]
+    fn test_manifest_load_complete() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["dome", "env", "dc"]
+type = "tofu"
+overwrite = true
+allowList = ["mgmt", "stg"]
+optDims = ["region"]
+affinityTags = ["core"]
+
+[runner]
+state_backend = "local"
+runner_command = "/usr/bin/tofu"
+inlet_command = "echo inlet"
+outlet_command = "echo outlet"
+
+[state]
+path = "~/.cubtera/state"
+
+[spec]
+tfVersion = "1.5.0"
+
+[spec.envVars.required]
+API_KEY = "API_KEY"
+
+[spec.files.required]
+"~/.config/file" = "config"
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert_eq!(manifest.dimensions, vec!["dome", "env", "dc"]);
+        assert_eq!(manifest.unit_type, "tofu");
+        assert!(manifest.overwrite);
+        assert_eq!(manifest.allow_list, Some(vec!["mgmt".to_string(), "stg".to_string()]));
+        assert_eq!(manifest.opt_dims, Some(vec!["region".to_string()]));
+        assert_eq!(manifest.affinity_tags, Some(vec!["core".to_string()]));
+
+        let runner = manifest.runner.unwrap();
+        assert_eq!(runner.get("state_backend"), Some(&"local".to_string()));
+        assert_eq!(runner.get("runner_command"), Some(&"/usr/bin/tofu".to_string()));
+        assert_eq!(runner.get("inlet_command"), Some(&"echo inlet".to_string()));
+        assert_eq!(runner.get("outlet_command"), Some(&"echo outlet".to_string()));
+
+        let state = manifest.state.unwrap();
+        assert_eq!(state.get("path"), Some(&"~/.cubtera/state".to_string()));
+    }
+
+    #[test]
+    fn test_manifest_load_missing_file() {
+        let dir = tempdir().unwrap();
+        // Don't create the manifest file
+
+        let result = Manifest::load(dir.path());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Failed to read unit manifest"));
+    }
+
+    #[test]
+    fn test_manifest_load_invalid_toml() {
+        let dir = tempdir().unwrap();
+        let content = "this is not valid toml [[[";
+        create_manifest_file(dir.path(), content);
+
+        let result = Manifest::load(dir.path());
+
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("Failed to parse manifest"));
+    }
+
+    #[test]
+    fn test_manifest_load_missing_required_fields() {
+        let dir = tempdir().unwrap();
+        // Missing 'dimensions' and 'type'
+        let content = r#"
+overwrite = true
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let result = Manifest::load(dir.path());
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_manifest_serialization_roundtrip() {
+        let manifest = Manifest {
+            dimensions: vec!["env".to_string(), "dc".to_string()],
+            overwrite: true,
+            opt_dims: Some(vec!["region".to_string()]),
+            allow_list: Some(vec!["prod".to_string()]),
+            deny_list: None,
+            affinity_tags: None,
+            unit_type: "tf".to_string(),
+            spec: None,
+            runner: None,
+            state: None,
+        };
+
+        let json = serde_json::to_string(&manifest).unwrap();
+        let deserialized: Manifest = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(manifest.dimensions, deserialized.dimensions);
+        assert_eq!(manifest.unit_type, deserialized.unit_type);
+        assert_eq!(manifest.overwrite, deserialized.overwrite);
+        assert_eq!(manifest.opt_dims, deserialized.opt_dims);
+        assert_eq!(manifest.allow_list, deserialized.allow_list);
+    }
+
+    #[test]
+    fn test_env_vars_struct() {
+        let mut required: HashMap<String, String> = HashMap::new();
+        required.insert("KEY1".to_string(), "VALUE1".to_string());
+
+        let mut optional: HashMap<String, String> = HashMap::new();
+        optional.insert("KEY2".to_string(), "VALUE2".to_string());
+
+        let env_vars = EnvVars {
+            required: Some(required.clone()),
+            optional: Some(optional.clone()),
+        };
+
+        let json = serde_json::to_string(&env_vars).unwrap();
+        let deserialized: EnvVars = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(env_vars, deserialized);
+    }
+
+    #[test]
+    fn test_files_struct() {
+        let mut required: HashMap<String, String> = HashMap::new();
+        required.insert("src".to_string(), "dst".to_string());
+
+        let files = Files {
+            required: Some(required.clone()),
+            optional: None,
+        };
+
+        let json = serde_json::to_string(&files).unwrap();
+        let deserialized: Files = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(files, deserialized);
+    }
+
+    #[test]
+    fn test_spec_struct() {
+        let spec = Spec {
+            tf_version: Some("1.5.0".to_string()),
+            env_vars: None,
+            files: None,
+        };
+
+        let json = serde_json::to_string(&spec).unwrap();
+        let deserialized: Spec = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(spec.tf_version, deserialized.tf_version);
+    }
+
+    #[test]
+    fn test_manifest_unit_types() {
+        let test_cases = vec!["tf", "bash", "tofu"];
+
+        for unit_type in test_cases {
+            let dir = tempdir().unwrap();
+            let content = format!(
+                r#"
+dimensions = ["env"]
+type = "{}"
+"#,
+                unit_type
+            );
+            create_manifest_file(dir.path(), &content);
+
+            let manifest = Manifest::load(dir.path()).unwrap();
+            assert_eq!(manifest.unit_type, unit_type);
+        }
+    }
+
+    #[test]
+    fn test_manifest_alias_opt_dims() {
+        // Test that both 'optDims' (camelCase) and 'opt_dims' (snake_case) work
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+opt_dims = ["region", "zone"]
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.opt_dims.is_some());
+        assert_eq!(manifest.opt_dims.unwrap(), vec!["region", "zone"]);
+    }
+
+    #[test]
+    fn test_manifest_alias_allow_list() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+allow_list = ["prod"]
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.allow_list.is_some());
+        assert_eq!(manifest.allow_list.unwrap(), vec!["prod"]);
+    }
+
+    #[test]
+    fn test_manifest_alias_deny_list() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+deny_list = ["dev"]
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.deny_list.is_some());
+        assert_eq!(manifest.deny_list.unwrap(), vec!["dev"]);
+    }
+
+    #[test]
+    fn test_manifest_alias_affinity_tags() {
+        let dir = tempdir().unwrap();
+        let content = r#"
+dimensions = ["env"]
+type = "tf"
+affinity_tags = ["tag1"]
+"#;
+        create_manifest_file(dir.path(), content);
+
+        let manifest = Manifest::load(dir.path()).unwrap();
+
+        assert!(manifest.affinity_tags.is_some());
+        assert_eq!(manifest.affinity_tags.unwrap(), vec!["tag1"]);
+    }
+}

--- a/tests/api_tests.rs
+++ b/tests/api_tests.rs
@@ -1,0 +1,349 @@
+//! API integration tests for Cubtera
+//!
+//! These tests verify the API server endpoints and responses.
+//! Note: Most endpoints require MongoDB, so we focus on structure and the health endpoint.
+
+use rocket::http::Status;
+use rocket::local::blocking::Client;
+use serde_json::Value;
+
+/// Create a test client using the API's rocket instance
+/// Note: This will create a real Rocket instance
+fn get_client() -> Option<Client> {
+    // Import the api module - we'll use a synchronous test client
+    // This requires the api to be properly configured
+
+    // For tests that don't require the full API, we create a minimal rocket instance
+    let rocket = rocket::build()
+        .mount("/", rocket::routes![health_test])
+        .mount("/v1", rocket::routes![orgs_mock]);
+
+    Client::tracked(rocket).ok()
+}
+
+// Mock routes for testing
+#[rocket::get("/health")]
+fn health_test() -> rocket::serde::json::Value {
+    rocket::serde::json::json!({
+        "status": "success",
+        "message": "Cubtera is alive...",
+    })
+}
+
+#[rocket::get("/orgs")]
+fn orgs_mock() -> rocket::serde::json::Value {
+    rocket::serde::json::json!({
+        "status": "ok",
+        "id": "orgs",
+        "data": ["cubtera", "testorg"]
+    })
+}
+
+// ========== Health Endpoint Tests ==========
+
+#[test]
+fn test_health_endpoint() {
+    let client = get_client().expect("Failed to create client");
+    let response = client.get("/health").dispatch();
+
+    assert_eq!(response.status(), Status::Ok);
+
+    let body = response.into_string().unwrap();
+    let json: Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(json["status"], "success");
+    assert_eq!(json["message"], "Cubtera is alive...");
+}
+
+#[test]
+fn test_health_returns_json() {
+    let client = get_client().expect("Failed to create client");
+    let response = client.get("/health").dispatch();
+
+    let body = response.into_string().unwrap();
+
+    // Verify the response is valid JSON
+    let parsed: Result<Value, _> = serde_json::from_str(&body);
+    assert!(parsed.is_ok());
+}
+
+// ========== API Structure Tests ==========
+
+#[test]
+fn test_orgs_endpoint_mock() {
+    let client = get_client().expect("Failed to create client");
+    let response = client.get("/v1/orgs").dispatch();
+
+    assert_eq!(response.status(), Status::Ok);
+
+    let body = response.into_string().unwrap();
+    let json: Value = serde_json::from_str(&body).unwrap();
+
+    assert_eq!(json["status"], "ok");
+    assert_eq!(json["id"], "orgs");
+    assert!(json["data"].is_array());
+}
+
+// ========== 404 Handler Tests ==========
+
+#[test]
+fn test_not_found_handler() {
+    let client = get_client().expect("Failed to create client");
+    let response = client.get("/nonexistent/path").dispatch();
+
+    assert_eq!(response.status(), Status::NotFound);
+}
+
+#[test]
+fn test_invalid_api_path() {
+    let client = get_client().expect("Failed to create client");
+    let response = client.get("/v1/invalid/endpoint").dispatch();
+
+    assert_eq!(response.status(), Status::NotFound);
+}
+
+// ========== Response Format Tests ==========
+
+mod response_format_tests {
+    use serde_json::json;
+
+    #[test]
+    fn test_expected_dim_types_response_format() {
+        let expected_response = json!({
+            "status": "ok",
+            "id": "dimTypes",
+            "org": "cubtera",
+            "data": ["dome", "env", "dc"]
+        });
+
+        assert!(expected_response["status"].is_string());
+        assert!(expected_response["id"].is_string());
+        assert!(expected_response["org"].is_string());
+        assert!(expected_response["data"].is_array());
+    }
+
+    #[test]
+    fn test_expected_dims_by_type_response_format() {
+        let expected_response = json!({
+            "status": "ok",
+            "id": "dimsByType",
+            "type": "env",
+            "data": ["prod", "staging", "dev"]
+        });
+
+        assert_eq!(expected_response["id"], "dimsByType");
+        assert!(expected_response["data"].is_array());
+    }
+
+    #[test]
+    fn test_expected_dim_by_name_response_format() {
+        let expected_response = json!({
+            "status": "ok",
+            "id": "dimByName",
+            "type": "env",
+            "name": "prod",
+            "data": {
+                "name": "prod",
+                "parent": "dome:prod",
+                "meta": {}
+            }
+        });
+
+        assert_eq!(expected_response["id"], "dimByName");
+        assert!(expected_response["data"].is_object());
+    }
+
+    #[test]
+    fn test_expected_dim_defaults_response_format() {
+        let expected_response = json!({
+            "status": "ok",
+            "id": "dimsDefaultsByType",
+            "type": "env",
+            "data": {}
+        });
+
+        assert_eq!(expected_response["id"], "dimsDefaultsByType");
+    }
+
+    #[test]
+    fn test_expected_dim_parent_response_format() {
+        let expected_response = json!({
+            "status": "ok",
+            "id": "dimParent",
+            "type": "dome",
+            "name": "prod",
+            "data": {}
+        });
+
+        assert_eq!(expected_response["id"], "dimParent");
+    }
+
+    #[test]
+    fn test_expected_dims_by_parent_response_format() {
+        let expected_response = json!({
+            "status": "ok",
+            "id": "dimsByParent",
+            "parent_type": "dome",
+            "parent_name": "prod",
+            "data": {
+                "dim_type": "env",
+                "dim_names": ["prod", "staging"]
+            }
+        });
+
+        assert_eq!(expected_response["id"], "dimsByParent");
+        assert!(expected_response["data"]["dim_names"].is_array());
+    }
+
+    #[test]
+    fn test_expected_orgs_response_format() {
+        let expected_response = json!({
+            "status": "ok",
+            "id": "orgs",
+            "data": ["cubtera", "org2"]
+        });
+
+        assert_eq!(expected_response["id"], "orgs");
+        assert!(expected_response["data"].is_array());
+    }
+
+    #[test]
+    fn test_error_response_format() {
+        let error_response = json!({
+            "status": "error",
+            "id": "dimParent",
+            "message": "No parent dim found",
+            "data": null
+        });
+
+        assert_eq!(error_response["status"], "error");
+        assert!(error_response["message"].is_string());
+        assert!(error_response["data"].is_null());
+    }
+}
+
+// ========== API Route URL Tests ==========
+
+mod api_route_tests {
+    #[test]
+    fn test_v1_route_prefix() {
+        let routes = vec![
+            "/v1/org/dimTypes",
+            "/v1/org/dims",
+            "/v1/org/dimsData",
+            "/v1/org/dim",
+            "/v1/org/dimDefaults",
+            "/v1/org/dimParent",
+            "/v1/org/dimsByParent",
+            "/v1/orgs",
+        ];
+
+        for route in routes {
+            assert!(route.starts_with("/v1"));
+        }
+    }
+
+    #[test]
+    fn test_query_parameter_formats() {
+        // dims?type=env
+        let query1 = "type=env";
+        assert!(query1.contains("type="));
+
+        // dim?type=env&name=prod
+        let query2 = "type=env&name=prod";
+        assert!(query2.contains("type="));
+        assert!(query2.contains("name="));
+
+        // dim?type=env&name=prod&context=branch:feature
+        let query3 = "type=env&name=prod&context=branch:feature";
+        assert!(query3.contains("context="));
+    }
+}
+
+// ========== ApiKey Guard Tests ==========
+
+mod api_key_tests {
+    use rocket::http::Header;
+
+    #[test]
+    fn test_api_key_header_format() {
+        // The API expects x-api-key header
+        let header = Header::new("x-api-key", "123456789");
+        assert_eq!(header.name().as_str(), "x-api-key");
+    }
+
+    #[test]
+    fn test_expected_api_key_values() {
+        // Test that we understand the API key validation logic
+        fn is_valid(key: &str) -> bool {
+            key == "123456789"
+        }
+
+        assert!(is_valid("123456789"));
+        assert!(!is_valid("invalid"));
+        assert!(!is_valid(""));
+    }
+}
+
+// ========== Endpoint Parameter Validation Tests ==========
+
+mod parameter_validation_tests {
+    #[test]
+    fn test_dim_type_parameter() {
+        let valid_types = vec!["env", "dc", "dome", "service"];
+
+        for t in valid_types {
+            assert!(!t.is_empty());
+            assert!(!t.contains(' '));
+        }
+    }
+
+    #[test]
+    fn test_dim_name_parameter() {
+        let valid_names = vec!["prod", "staging", "us-east-1", "mgmt"];
+
+        for name in valid_names {
+            assert!(!name.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_context_parameter_format() {
+        // Context follows pattern: type:value
+        let valid_contexts = vec!["branch:feature-1", "pr:123", "env:test"];
+
+        for ctx in valid_contexts {
+            assert!(ctx.contains(':'));
+            let parts: Vec<&str> = ctx.split(':').collect();
+            assert_eq!(parts.len(), 2);
+        }
+    }
+
+    #[test]
+    fn test_limit_parameter() {
+        // Limit should be a positive integer
+        let valid_limits = vec![1, 10, 100];
+
+        for limit in valid_limits {
+            assert!(limit > 0);
+        }
+    }
+}
+
+// ========== Content Type Tests ==========
+
+mod content_type_tests {
+    use super::*;
+
+    #[test]
+    fn test_json_content_type() {
+        let client = get_client().expect("Failed to create client");
+        let response = client.get("/health").dispatch();
+
+        // Rocket JSON responses should have appropriate content type
+        let content_type = response.content_type();
+        // Note: Rocket::serde::json::Value returns application/json
+        assert!(content_type.is_some() || response.status() == Status::Ok);
+    }
+}
+

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -1,0 +1,402 @@
+//! CLI integration tests for Cubtera
+//!
+//! These tests run the actual CLI binary and verify its behavior.
+//! Tests use the example directory as a fixture for inventory and units.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::env;
+use std::path::PathBuf;
+
+/// Get the path to the example directory for test fixtures
+fn get_example_path() -> PathBuf {
+    let manifest_dir = env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".to_string());
+    PathBuf::from(manifest_dir).join("example")
+}
+
+/// Get a command configured with the example workspace
+fn get_cmd() -> Command {
+    let mut cmd = Command::cargo_bin("cubtera").unwrap();
+    let example_path = get_example_path();
+
+    // Configure environment for tests
+    cmd.env("CUBTERA_WORKSPACE_PATH", example_path.to_str().unwrap())
+        .env("CUBTERA_ORG", "cubtera")
+        .env("CUBTERA_CONFIG", example_path.join("config.toml").to_str().unwrap())
+        .env("CUBTERA_LOG", "error"); // Suppress logging in tests
+
+    cmd
+}
+
+// ========== Basic CLI Tests ==========
+
+#[test]
+fn test_cli_no_args_shows_help() {
+    let mut cmd = get_cmd();
+
+    cmd.assert()
+        .failure()
+        .stderr(predicate::str::contains("Usage:"));
+}
+
+#[test]
+fn test_cli_help_flag() {
+    let mut cmd = get_cmd();
+
+    cmd.arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Immersive cubic dimensions experience"))
+        .stdout(predicate::str::contains("im"))
+        .stdout(predicate::str::contains("run"))
+        .stdout(predicate::str::contains("config"));
+}
+
+#[test]
+fn test_cli_version_flag() {
+    let mut cmd = get_cmd();
+
+    cmd.arg("--version")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("cubtera"));
+}
+
+// ========== Config Command Tests ==========
+
+#[test]
+fn test_config_command() {
+    let mut cmd = get_cmd();
+
+    cmd.arg("config")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("workspace_path"))
+        .stdout(predicate::str::contains("org"));
+}
+
+#[test]
+fn test_config_alias_cfg() {
+    let mut cmd = get_cmd();
+
+    cmd.arg("cfg")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("workspace_path"));
+}
+
+// ========== IM (Inventory Management) Command Tests ==========
+
+#[test]
+fn test_im_help() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Inventory management"))
+        .stdout(predicate::str::contains("getAll"))
+        .stdout(predicate::str::contains("getByName"));
+}
+
+#[test]
+fn test_im_getall_help() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getAll", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("dim_type"));
+}
+
+#[test]
+fn test_im_getbyname_help() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getByName", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("dim_type"))
+        .stdout(predicate::str::contains("dim_name"));
+}
+
+#[test]
+fn test_im_getall_env() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getAll", "env"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("dimsByType"));
+}
+
+#[test]
+fn test_im_getall_dome() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getAll", "dome"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("dimsByType"));
+}
+
+#[test]
+fn test_im_getall_dc() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getAll", "dc"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("dimsByType"));
+}
+
+#[test]
+fn test_im_getbyname_env_prod() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getByName", "env", "prod"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("dimByName"))
+        .stdout(predicate::str::contains("prod"));
+}
+
+#[test]
+fn test_im_getbyname_dome_prod() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getByName", "dome", "prod"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("dimByName"))
+        .stdout(predicate::str::contains("prod"));
+}
+
+#[test]
+fn test_im_getdefaults_env() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getDefaults", "env"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("dimsDefaultsByType"));
+}
+
+#[test]
+fn test_im_getorgs() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getOrgs"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("orgs"))
+        .stdout(predicate::str::contains("cubtera"));
+}
+
+#[test]
+fn test_im_getbyparent() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getByParent", "dome", "prod"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("dimsByParent"));
+}
+
+#[test]
+fn test_im_getparent() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getParent", "env", "prod"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("dimParent"));
+}
+
+#[test]
+fn test_im_getalldata_env() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getAllData", "env"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("status"))
+        .stdout(predicate::str::contains("dimsDataByType"));
+}
+
+// ========== Log Command Tests ==========
+
+#[test]
+fn test_log_help() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["log", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Deployment log"));
+}
+
+#[test]
+fn test_log_get_help() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["log", "get", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("query"));
+}
+
+// Note: log get requires dlog_db to be configured, so we just test the help
+
+// ========== Run Command Tests ==========
+
+#[test]
+fn test_run_help() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["run", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Run unit"))
+        .stdout(predicate::str::contains("--unit"))
+        .stdout(predicate::str::contains("--dim"));
+}
+
+#[test]
+fn test_run_alias_tf() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["tf", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Run unit"));
+}
+
+// ========== Environment Variable Tests ==========
+
+#[test]
+fn test_custom_org_env() {
+    let mut cmd = Command::cargo_bin("cubtera").unwrap();
+    let example_path = get_example_path();
+
+    cmd.env("CUBTERA_WORKSPACE_PATH", example_path.to_str().unwrap())
+        .env("CUBTERA_ORG", "customorg")
+        .env("CUBTERA_CONFIG", example_path.join("config.toml").to_str().unwrap())
+        .env("CUBTERA_LOG", "error")
+        .arg("config")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("customorg"));
+}
+
+// ========== Error Handling Tests ==========
+
+#[test]
+fn test_invalid_subcommand() {
+    let mut cmd = get_cmd();
+
+    cmd.arg("invalid_subcommand")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("error"));
+}
+
+#[test]
+fn test_im_missing_dim_type() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getAll"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("dim_type"));
+}
+
+#[test]
+fn test_im_getbyname_missing_args() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "getByName", "env"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("dim_name"));
+}
+
+// ========== Response Format Tests ==========
+
+#[test]
+fn test_im_response_is_json() {
+    let mut cmd = get_cmd();
+
+    let output = cmd
+        .args(["im", "getAll", "env"])
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Verify it's valid JSON
+    let parsed: Result<serde_json::Value, _> = serde_json::from_str(&stdout);
+    assert!(parsed.is_ok(), "Output should be valid JSON: {}", stdout);
+}
+
+#[test]
+fn test_config_response_is_json() {
+    let mut cmd = get_cmd();
+
+    let output = cmd
+        .arg("config")
+        .output()
+        .expect("Failed to execute command");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Verify it's valid JSON
+    let parsed: Result<serde_json::Value, _> = serde_json::from_str(&stdout);
+    assert!(parsed.is_ok(), "Config output should be valid JSON: {}", stdout);
+}
+
+// ========== IM Subcommand Validation Tests ==========
+
+#[test]
+fn test_im_validate_help() {
+    let mut cmd = get_cmd();
+
+    cmd.args(["im", "validate", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Validate"));
+}
+
+// ========== Dimension Type Tests ==========
+
+#[test]
+fn test_im_nonexistent_dim_type() {
+    let mut cmd = get_cmd();
+
+    // Nonexistent dim types fail (exit with error)
+    cmd.args(["im", "getAll", "nonexistent"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Can't read data folder"));
+}
+
+#[test]
+fn test_im_nonexistent_dim_name() {
+    let mut cmd = get_cmd();
+
+    // Nonexistent dim names fail (exit with error)
+    cmd.args(["im", "getByName", "env", "nonexistent"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("Can't find"));
+}
+


### PR DESCRIPTION
…nit management

- Introduced unit tests for `CubteraConfig`, validating default values, path definitions, and serialization.
- Added tests for `Storage` enum, ensuring correct behavior for different storage types.
- Implemented tests for `Dlog`, covering serialization, deserialization, and handling of environment variables.
- Enhanced `Unit` tests to verify state path generation, dimension handling, and manifest loading.
- Included tests for manifest file parsing, ensuring correct handling of various configurations and error cases.
- Improved overall test coverage for core components, ensuring robustness and reliability of the codebase.

# Pull Request Template

## Description

Please include a summary of the change and which issue (if any) is fixed.
A brief description of the algorithm and your implementation method can be helpful too. If the implemented method/algorithm is not so well-known, it would be helpful to add a link to an article explaining it with more details.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [ ] I ran bellow commands using the latest version of **rust nightly**.
- [ ] I ran `cargo clippy --all -- -D warning` just before my last commit and fixed any issue that was found.
- [ ] I ran `cargo fmt` just before my last commit.
- [ ] I ran `cargo test` just before my last commit and all tests passed.
- [ ] I checked `COUNTRIBUTING.md` and my code follows its guidelines.

Please make sure that if there is a test that takes too long to run ( > 300ms), you `#[ignore]` that or try to optimize your code or make the test easier to run. We have this rule because we have hundreds of tests to run; If each one of them took 300ms, we would have to wait for a long time.