### PR TITLE
feat(runner): add dLog support to BashRunner

### DIFF
--- a/src/core/runner/bash/mod.rs
+++ b/src/core/runner/bash/mod.rs
@@ -2,7 +2,9 @@
 // Using default Runner Trait implementation's methods
 
 use super::{Runner, RunnerLoad};
-use serde_json::Value;
+use crate::prelude::*;
+use log::{debug, info};
+use serde_json::{json, Value};
 
 pub struct BashRunner {
     load: RunnerLoad,
@@ -25,5 +27,35 @@ impl Runner for BashRunner {
 
     fn get_ctx_mut(&mut self) -> &mut Value {
         &mut self.ctx
+    }
+
+    fn logger(&mut self) -> Result<(), Box<dyn std::error::Error>> {
+        debug!(target: "bash runner", "Logger method.");
+
+        if GLOBAL_CFG.dlog_db.is_some() {
+            let exit_code = self.ctx.get("runner_exit_code")
+                .and_then(|v| v.as_i64())
+                .unwrap_or(0) as i32;
+
+            // Команда может быть пустой
+            let command = self.load.command.first()
+                .map(|s| s.as_str())
+                .unwrap_or("");
+
+            let dlog = Dlog::build(
+                self.load.unit.clone(),
+                command.into(),
+                exit_code
+            );
+            let _ = dlog
+                .put(&GLOBAL_CFG.org)
+                .check_with_warn("Can't put dlog to DB");
+            info!(target: "bash runner", "Dlog data was saved");
+        }
+
+        self.update_ctx("logger", json!("executed"));
+        debug!(target: "bash runner", "Final context: {}", self.ctx.to_string());
+
+        Ok(())
     }
 }

--- a/src/core/runner/bash/mod.rs
+++ b/src/core/runner/bash/mod.rs
@@ -37,7 +37,6 @@ impl Runner for BashRunner {
                 .and_then(|v| v.as_i64())
                 .unwrap_or(0) as i32;
 
-            // Команда может быть пустой
             let command = self.load.command.first()
                 .map(|s| s.as_str())
                 .unwrap_or("");


### PR DESCRIPTION
## Summary

Add deployment logging (dLog) support to BashRunner, matching the functionality already present in TfRunner.

## Changes

- Override `logger()` method in BashRunner to write deployment logs to MongoDB
- Log the command (or empty string if not provided) and exit code
- Only logs when `dlog_db` is configured in global config

## Testing

- `cargo check` passes
- Follows existing dLog pattern from TfRunner